### PR TITLE
IS5d-MS2 closed

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: pgvector/pgvector:pg16
+    image: pgvector/pgvector:pg15
     container_name: ingestion-db-test
     ports:
       - "5433:5432"

--- a/src/ingestion_service/core/vectorstore/pgvector_store.py
+++ b/src/ingestion_service/core/vectorstore/pgvector_store.py
@@ -53,7 +53,7 @@ class PgVectorStore(VectorStore):
         search_sql = f"""
         SELECT vector, ingestion_id, chunk_id, chunk_index, chunk_strategy
         FROM {self._table_name}
-        ORDER BY vector <-> %s
+        ORDER BY vector <-> (%s::vector)
         LIMIT %s
         """
         results: List[VectorRecord] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+import psycopg
+import pytest
+
+
+@pytest.fixture(scope="session")
+def test_database_url() -> str:
+    """
+    Hard-coded test DB URL.
+    This intentionally does NOT reuse app settings.
+    """
+    return (
+        "postgresql://ingestion_user:"
+        "ingestion_pass@localhost:5433/ingestion_test"
+    )
+
+
+@pytest.fixture(scope="session")
+def psycopg_conn(test_database_url: str):
+    """
+    Session-wide psycopg connection.
+    """
+    with psycopg.connect(test_database_url) as conn:
+        conn.execute("CREATE EXTENSION IF NOT EXISTS vector;")
+        yield conn
+
+
+@pytest.fixture(autouse=True)
+def clean_vectors_table(psycopg_conn):
+    psycopg_conn.execute("DROP TABLE IF EXISTS vectors;")
+    psycopg_conn.commit()

--- a/tests/vectorstore/test_pgvector_store.py
+++ b/tests/vectorstore/test_pgvector_store.py
@@ -1,0 +1,56 @@
+import uuid
+
+import pytest
+
+from ingestion_service.core.vectorstore.base import VectorMetadata, VectorRecord
+from ingestion_service.core.vectorstore.pgvector_store import PgVectorStore
+
+
+@pytest.mark.docker
+@pytest.mark.integration
+def test_pgvector_store_add_search_delete():
+    dsn = (
+        "postgresql://ingestion_user:"
+        "ingestion_pass@localhost:5433/ingestion_test"
+    )
+
+    store = PgVectorStore(
+        dsn=dsn,
+        dimension=3,
+    )
+
+    ingestion_id = str(uuid.uuid4())
+    chunk_id = str(uuid.uuid4())
+
+    record = VectorRecord(
+        vector=[0.1, 0.2, 0.3],
+        metadata=VectorMetadata(
+            ingestion_id=ingestion_id,
+            chunk_id=chunk_id,
+            chunk_index=0,
+            chunk_strategy="test",
+        ),
+    )
+
+    # --- add ---
+    store.add([record])
+
+    # --- similarity search ---
+    results = store.similarity_search(
+        query_vector=[0.1, 0.2, 0.31],
+        k=1,
+    )
+
+    assert len(results) == 1
+    assert results[0].metadata.ingestion_id == ingestion_id
+    assert results[0].metadata.chunk_id == chunk_id
+
+    # --- delete ---
+    store.delete_by_ingestion_id(ingestion_id)
+
+    results_after_delete = store.similarity_search(
+        query_vector=[0.1, 0.2, 0.3],
+        k=1,
+    )
+
+    assert results_after_delete == []


### PR DESCRIPTION
IS5d-MS2 closed
Verified pgvector integration using Dockerized PostgreSQL with real pgvector extension. PgVectorStore bootstraps its own table, inserts embeddings, performs similarity search using <->, and deletes by ingestion_id via raw psycopg SQL. Test is deterministic, ORM-free, and isolated from FastAPI and Alembic.