### PR TITLE
IS2-ms3 passed

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -21,6 +21,7 @@ services:
     environment:
       DATABASE_URL: postgresql://ingestion_user:ingestion_pass@postgres:5432/ingestion_test
       PYTHONPATH: /app/src
+      EMBEDDING_PROVIDER: ollama
     volumes:
       - ./src/ingestion_service:/app/src/ingestion_service
     depends_on:

--- a/migrations/versions/20251229_add_vectors_table.py
+++ b/migrations/versions/20251229_add_vectors_table.py
@@ -1,4 +1,4 @@
-"""Add vectors table using pgvector (with chunk text + metadata)
+"""Add vectors table using pgvector (with chunk text + metadata + provider)
 
 Revision ID: 20251229_add_vectors_table
 Revises: bb0f22648df9
@@ -18,7 +18,7 @@ def upgrade() -> None:
     # Enable pgvector extension
     op.execute("CREATE EXTENSION IF NOT EXISTS vector")
 
-    # Create vectors table (MVP schema)
+    # Create vectors table with provider column
     op.execute(
         """
         CREATE TABLE IF NOT EXISTS ingestion_service.vectors (
@@ -29,7 +29,8 @@ def upgrade() -> None:
             chunk_index INT NOT NULL,
             chunk_strategy TEXT NOT NULL,
             chunk_text TEXT NOT NULL,
-            source_metadata JSONB NOT NULL DEFAULT '{}'
+            source_metadata JSONB NOT NULL DEFAULT '{}',
+            provider TEXT NOT NULL DEFAULT 'mock'
         )
         """
     )

--- a/src/ingestion_service/api/v1/ingest.py
+++ b/src/ingestion_service/api/v1/ingest.py
@@ -26,16 +26,13 @@ class NoOpValidator:
 
 
 def _build_pipeline() -> IngestionPipeline:
-    """
-    Build ingestion pipeline using the factory embedder
-    and PgVectorStore.
-    """
     settings = get_settings()
     embedder = get_embedder(settings.EMBEDDING_PROVIDER)
 
     vector_store = PgVectorStore(
         dsn=settings.DATABASE_URL,
-        dimension=getattr(embedder, "dimension", 3),  # default 3 for MockEmbedder
+        dimension=getattr(embedder, "dimension", 3),
+        provider=settings.EMBEDDING_PROVIDER,
     )
 
     return IngestionPipeline(

--- a/src/ingestion_service/core/embedders/factory.py
+++ b/src/ingestion_service/core/embedders/factory.py
@@ -2,6 +2,9 @@
 from ingestion_service.core.embedders.mock import MockEmbedder
 from ingestion_service.core.embedders.ollama import OllamaEmbedder
 from ingestion_service.core.config import get_settings
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
 
 
 def get_embedder(provider: str | None = None):
@@ -11,17 +14,24 @@ def get_embedder(provider: str | None = None):
     - If provider is "ollama", returns OllamaEmbedder
     - Otherwise, returns MockEmbedder
     """
+    logging.debug("get_embedder provider %s", provider)
     settings = get_settings()
     # Ensure provider is a string
     provider_str: str = (
         provider if provider is not None else settings.EMBEDDING_PROVIDER
     )
+    VALID_PROVIDERS = {"ollama", "mock"}
 
     if provider_str == "ollama":
+        logging.debug("settings.OLLAMA_BASE_URL : %s", settings.OLLAMA_BASE_URL)
+        logging.debug("settings.OLLAMA_EMBED_MODEL : %s", settings.OLLAMA_EMBED_MODEL)
         return OllamaEmbedder(
             base_url=settings.OLLAMA_BASE_URL,
             model=settings.OLLAMA_EMBED_MODEL,
             batch_size=settings.OLLAMA_BATCH_SIZE,
         )
-    else:
+    elif provider_str == "mock":  # ← EXPLICIT
         return MockEmbedder()
+    else:
+        raise ValueError(f"Unknown embedder provider: '{provider_str}'.\
+                          Valid: {VALID_PROVIDERS}")

--- a/src/ingestion_service/core/embedders/ollama.py
+++ b/src/ingestion_service/core/embedders/ollama.py
@@ -1,34 +1,50 @@
 # src/ingestion_service/core/embedders/ollama.py
 import requests
+import logging
+from typing import List
+
+from ingestion_service.core.embedders.base import BaseEmbedder
+from ingestion_service.core.chunks import Chunk
+
+logging.basicConfig(level=logging.DEBUG)
 
 
-class OllamaEmbedder:
-    """
-    Embedder using Ollama API.
-    """
-
-    dimension = 768  # Ollama model output dimension
+class OllamaEmbedder(BaseEmbedder):
+    name = "ollama"
+    dimension = 768
 
     def __init__(self, base_url: str, model: str, batch_size: int = 50):
         self.base_url = base_url.rstrip("/")
         self.model = model
         self.batch_size = batch_size
+        logging.debug("OllamaEmbedder self.base_url %s", self.base_url)
+        logging.debug("OllamaEmbedder self.model %s", self.model)
 
-    def embed(self, texts: list[str]) -> list[list[float]]:
-        """
-        Generate embeddings for a list of texts.
-        """
+    def embed(self, chunks: List[Chunk]) -> List[List[float]]:
+        logging.debug(
+            "OllamaEmbedder received %d items, types: %s",
+            len(chunks),
+            [type(c).__name__ for c in chunks[:3]],
+        )
+        texts = [chunk.content for chunk in chunks]
         try:
-            payload = {"model": self.model, "texts": texts}
-            response = requests.post(f"{self.base_url}/embeddings", json=payload)
+            payload = {"model": self.model, "input": texts}
+            logging.debug("OllamaEmbedder.embed payload %s", payload)
+            logging.debug("OllamaEmbedder starting embedding")
+            response = requests.post(f"{self.base_url}/api/embed", json=payload)
+            logging.debug("OllamaEmbedder finished embedding")
+            logging.debug("OllamaEmbedder response: %s", response)
             if response.status_code != 200:
                 raise RuntimeError(
                     f"Ollama embedding failed "
                     f"(status={response.status_code}): {response.text}"
                 )
             result = response.json()
-            # Assume API returns list of embeddings
-            return result["embeddings"]
+            logging.debug("OllamaEmbedder response.json: %s", result)
+            return (
+                result.get("embeddings", [result["embeddings"]])
+                if isinstance(texts, list)
+                else [result["embeddings"]]
+            )
         except Exception as e:
-            # In dev/test, fallback or re-raise for visibility
             raise RuntimeError(f"Ollama embedder error: {e}") from e

--- a/src/ingestion_service/core/pipeline.py
+++ b/src/ingestion_service/core/pipeline.py
@@ -1,11 +1,13 @@
 # src/ingestion_service/core/pipeline.py
-
 from __future__ import annotations
 from typing import Any, Optional
+import logging
 
 from ingestion_service.core.chunks import Chunk
 from ingestion_service.core.chunkers.base import BaseChunker
 from ingestion_service.core.chunkers.selector import ChunkerFactory
+
+logging.basicConfig(level=logging.DEBUG)
 
 
 class IngestionPipeline:
@@ -17,54 +19,21 @@ class IngestionPipeline:
         embedder,
         vector_store,
     ) -> None:
-        """
-        Initialize the pipeline with injected collaborators.
-
-        If `chunker` is None, a dynamic chunker will be selected at runtime
-        using ChunkerFactory.
-        """
         self._validator = validator
         self._chunker = chunker
         self._embedder = embedder
         self._vector_store = vector_store
 
-    # ============================================================
-    # Public entrypoint
-    # ============================================================
-
     def run(self, *, text: str, ingestion_id: str) -> None:
-        """
-        Execute the ingestion pipeline:
-
-        1. Validate input
-        2. Chunk into pieces
-        3. Generate embeddings
-        4. Persist chunks + embeddings
-        """
-
         self._validate(text)
         chunks = self._chunk(text)
         embeddings = self._embed(chunks)
         self._persist(chunks, embeddings, ingestion_id)
 
-    # ============================================================
-    # Pipeline steps
-    # ============================================================
-
     def _validate(self, text: str) -> None:
         self._validator.validate(text)
 
     def _chunk(self, text: str) -> list[Chunk]:
-        """
-        Chunk text using either:
-        - an explicitly provided chunker, or
-        - a dynamically selected chunker (factory / heuristic).
-
-        Enriches each Chunk with:
-        - chunk_strategy  (semantic strategy: simple / sentence / paragraph)
-        - chunker_name    (implementation identity)
-        - chunker_params  (parameters used)
-        """
         if self._chunker is None:
             selected_chunker, chunker_params = ChunkerFactory.choose_strategy(text)
         else:
@@ -72,31 +41,26 @@ class IngestionPipeline:
             chunker_params = {}
 
         chunks: list[Chunk] = selected_chunker.chunk(text, **chunker_params)
-
-        # Determine semantic strategy (preferred)
         chunk_strategy = getattr(selected_chunker, "chunk_strategy", None)
 
         for chunk in chunks:
-            # Semantic strategy used for chunking (THIS is what tests assert)
             chunk.metadata["chunk_strategy"] = (
                 chunk_strategy if chunk_strategy is not None else "unknown"
             )
-
-            # Concrete implementation name (useful for debugging / audits)
             chunk.metadata["chunker_name"] = getattr(
                 selected_chunker, "name", selected_chunker.__class__.__name__
             )
-
-            # Parameters used for chunking
             chunk.metadata["chunker_params"] = dict(chunker_params)
 
         return chunks
 
     def _embed(self, chunks: list[Chunk]) -> list[Any]:
-        """
-        Produce embeddings for a list of chunks.
-        """
-        return self._embedder.embed(chunks)
+        embeddings = self._embedder.embed(chunks)
+        if len(embeddings) != len(chunks):
+            raise ValueError(
+                f"Embedder mismatch: {len(chunks)} chunks, {len(embeddings)} embeddings"
+            )
+        return embeddings
 
     def _persist(
         self,
@@ -104,9 +68,11 @@ class IngestionPipeline:
         embeddings: list[Any],
         ingestion_id: str,
     ) -> None:
-        """
-        Persist chunks and embeddings to the vector store.
-        """
+        logging.debug(
+            "Pipeline: starting _persist: %d chunks, %d embeddings",
+            len(chunks),
+            len(embeddings),
+        )
         self._vector_store.persist(
             chunks=chunks,
             embeddings=embeddings,

--- a/src/ingestion_service/core/vectorstore/base.py
+++ b/src/ingestion_service/core/vectorstore/base.py
@@ -1,21 +1,23 @@
+# src/ingestion_service/core/vectorstore/base.py
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Iterable, Sequence, List
+from dataclasses import dataclass, field
+from typing import Iterable, Sequence, List, Dict, Optional
 
 
-@dataclass(frozen=True)
+@dataclass
 class VectorMetadata:
     ingestion_id: str
     chunk_id: str
     chunk_index: int
     chunk_strategy: str
     chunk_text: str
-    source_metadata: dict | None
+    source_metadata: Optional[Dict] = field(default_factory=dict)
+    provider: str = "mock"  # New attribute for provider name
 
 
-@dataclass(frozen=True)
+@dataclass
 class VectorRecord:
     vector: Sequence[float]
     metadata: VectorMetadata
@@ -24,17 +26,25 @@ class VectorRecord:
 class VectorStore(ABC):
     @property
     @abstractmethod
-    def dimension(self) -> int: ...
+    def dimension(self) -> int:
+        """Return the dimension of the vectors."""
+        ...
 
     @abstractmethod
-    def add(self, records: Iterable[VectorRecord]) -> None: ...
+    def add(self, records: Iterable[VectorRecord]) -> None:
+        """Add a list of VectorRecords to the store."""
+        ...
 
     @abstractmethod
     def similarity_search(
         self,
         query_vector: Sequence[float],
         k: int,
-    ) -> List[VectorRecord]: ...
+    ) -> List[VectorRecord]:
+        """Return the top k most similar vectors."""
+        ...
 
     @abstractmethod
-    def delete_by_ingestion_id(self, ingestion_id: str) -> None: ...
+    def delete_by_ingestion_id(self, ingestion_id: str) -> None:
+        """Delete all vectors associated with a given ingestion_id."""
+        ...

--- a/src/ingestion_service/test_embedding.py
+++ b/src/ingestion_service/test_embedding.py
@@ -1,9 +1,9 @@
 import requests
 
-url = "http://host.docker.internal:11434/api/embeddings"
+url = "http://host.docker.internal:11434/api/embed"
 payload = {
     "model": "nomic-embed-text:v1.5",
-    "prompt": "This is a test of the Ollama embedding API.",
+    "input": "This is a test of the Ollama embedding API.",
 }
 
 resp = requests.post(url, json=payload)

--- a/tests/core/pipeline/test_pipeline_persists_vectors.py
+++ b/tests/core/pipeline/test_pipeline_persists_vectors.py
@@ -1,59 +1,52 @@
 import uuid
 import pytest
+from typing import cast
 
 from ingestion_service.core.pipeline import IngestionPipeline
-from ingestion_service.core.headless_ingest import HeadlessIngestor
+from ingestion_service.core.embedders.ollama import OllamaEmbedder
+from ingestion_service.core.embedders.factory import get_embedder
 from ingestion_service.core.chunkers.text import TextChunker
-from ingestion_service.core.embedders.mock import MockEmbedder
 from ingestion_service.core.vectorstore.pgvector_store import PgVectorStore
+from ingestion_service.core.chunks import Chunk
+from ingestion_service.core.config import reset_settings_cache
 
 pytest_plugins = ["tests.conftest_db"]
 
 
-@pytest.mark.docker
 @pytest.mark.integration
+@pytest.mark.docker
 def test_pipeline_persists_vectors_pgvector(clean_vectors_table, test_database_url):
-    """
-    GIVEN text input
-    WHEN the ingestion pipeline runs
-    THEN chunk embeddings are persisted to pgvector with correct metadata
-    """
+    reset_settings_cache()
+
+    embedder = cast(OllamaEmbedder, get_embedder("ollama"))
+    assert embedder.dimension == 768
 
     vector_store = PgVectorStore(
         dsn=test_database_url,
-        dimension=3,
+        dimension=embedder.dimension,
+        provider="ollama",
     )
 
+    chunker = TextChunker(chunk_size=50, overlap=5, chunk_strategy="simple")
+    validator = type("Validator", (), {"validate": lambda self, text: None})()
+
     pipeline = IngestionPipeline(
-        validator=type(
-            "Validator",
-            (),
-            {"validate": lambda self, text: None},
-        )(),
-        chunker=TextChunker(chunk_size=50, overlap=0, chunk_strategy="simple"),
-        embedder=MockEmbedder(),
+        validator=validator,
+        chunker=chunker,
+        embedder=embedder,
         vector_store=vector_store,
     )
 
-    ingestor = HeadlessIngestor(pipeline)
-
-    text = "This is chunk one. This is chunk two. This is chunk three."
-
     ingestion_id = str(uuid.uuid4())
+    text = "This is a test document for Docker integration pipeline."
 
-    ingestor.ingest_text(text, ingestion_id)
+    # --- Test end-to-end pipeline ---
+    pipeline.run(text=text, ingestion_id=ingestion_id)
 
-    results = vector_store.similarity_search(
-        query_vector=[1.0, 1.0, 1.0],
-        k=10,
-    )
+    # --- Verify vectors persisted correctly ---
+    query_chunk = Chunk(chunk_id="query", content=text, metadata={})
+    query_embedding = embedder.embed([query_chunk])[0]
+    results = vector_store.similarity_search(query_vector=query_embedding, k=1)
 
-    persisted = [r for r in results if r.metadata.ingestion_id == ingestion_id]
-
-    assert len(persisted) > 0
-
-    for record in persisted:
-        assert record.vector is not None
-        assert record.metadata.chunk_id
-        assert record.metadata.chunk_index >= 0
-        assert record.metadata.chunk_strategy == "simple"
+    assert any(r.metadata.ingestion_id == ingestion_id for r in results)
+    assert any(r.metadata.chunk_strategy == "simple" for r in results)

--- a/tests/core/test_embedder_factory.py
+++ b/tests/core/test_embedder_factory.py
@@ -1,0 +1,23 @@
+# tests/core/test_embedder_factory.py - SIMPLE & BULLETPROOF
+import os
+from ingestion_service.core.embedders.factory import get_embedder
+from ingestion_service.core.config import reset_settings_cache
+
+def test_factory_ollama_explicit():
+    """get_embedder("ollama") → returns OllamaEmbedder instance."""
+    reset_settings_cache()
+    embedder = get_embedder("ollama")
+    assert embedder.name == "ollama"
+
+def test_factory_mock_explicit():
+    """get_embedder("mock") → returns MockEmbedder instance."""
+    reset_settings_cache()
+    embedder = get_embedder("mock")
+    assert embedder.name == "mock"
+
+def test_factory_config_fallback():
+    """No param → uses EMBEDDING_PROVIDER from .env/config."""
+    reset_settings_cache()
+    os.environ["EMBEDDING_PROVIDER"] = "mock"
+    embedder = get_embedder()  # Uses config
+    assert embedder.name == "mock"

--- a/tests/core/test_headless_ingest.py
+++ b/tests/core/test_headless_ingest.py
@@ -1,28 +1,37 @@
-# tests/core/test_headless_ingest.py
 import uuid
 import pytest
-
+from typing import cast
 from ingestion_service.core.headless_ingest import HeadlessIngestor
 from ingestion_service.core.pipeline import IngestionPipeline
-from ingestion_service.core.embedders.mock import MockEmbedder
+from ingestion_service.core.embedders.ollama import OllamaEmbedder
+from ingestion_service.core.embedders.factory import get_embedder
 from ingestion_service.core.chunkers.text import TextChunker
 from ingestion_service.core.vectorstore.pgvector_store import PgVectorStore
+from ingestion_service.core.chunks import Chunk
+from ingestion_service.core.config import reset_settings_cache
 
 pytest_plugins = ["tests.conftest_db"]
 
 
 @pytest.mark.integration
 @pytest.mark.docker
-def test_headless_ingestion_adds_vectors(test_database_url):
-    dsn = test_database_url
+def test_headless_ingestion_adds_vectors(clean_vectors_table, test_database_url):
+    reset_settings_cache()
 
-    # Use MockEmbedder and PgVectorStore
-    vector_store = PgVectorStore(dsn=dsn, dimension=3)
-    embedder = MockEmbedder()
-    chunker = TextChunker(chunk_size=100, overlap=10, chunk_strategy="simple")
+    embedder = cast(OllamaEmbedder, get_embedder("ollama"))
+    assert embedder.dimension == 768
+
+    vector_store = PgVectorStore(
+        dsn=test_database_url,
+        dimension=embedder.dimension,
+        provider="ollama",
+    )
+
+    chunker = TextChunker(chunk_size=50, overlap=5, chunk_strategy="simple")
+    validator = type("Validator", (), {"validate": lambda self, text: None})()
 
     pipeline = IngestionPipeline(
-        validator=type("Validator", (), {"validate": lambda self, text: None})(),
+        validator=validator,
         chunker=chunker,
         embedder=embedder,
         vector_store=vector_store,
@@ -30,12 +39,17 @@ def test_headless_ingestion_adds_vectors(test_database_url):
 
     ingestor = HeadlessIngestor(pipeline)
 
-    text = "This is a test document. It has multiple sentences. And multiple chunks."
+    text = "Headless ingestion Docker integration test with multiple sentences."
     ingestion_id = str(uuid.uuid4())
 
-    # Run ingestion
+    # --- Test end-to-end headless ingestion ---
     ingestor.ingest_text(text, ingestion_id)
 
-    # Verify that vectors are persisted
-    results = vector_store.similarity_search([1.0, 1.0, 1.0], k=10)
+    # --- Verify vectors persisted correctly ---
+    query_chunk = Chunk(chunk_id="query", content=text, metadata={})
+    query_embedding = embedder.embed([query_chunk])[0]
+    results = vector_store.similarity_search(query_vector=query_embedding, k=5)
+
+    # Verify ingestion_id present and chunk_strategy properly set
     assert any(r.metadata.ingestion_id == ingestion_id for r in results)
+    assert any(r.metadata.chunk_strategy == "simple" for r in results)

--- a/tests/vectorstore/test_pgvector_search.py
+++ b/tests/vectorstore/test_pgvector_search.py
@@ -1,52 +1,79 @@
-# tests/vectorstore/test_pgvector_search.py
 import pytest
+from typing import cast
 
+from ingestion_service.core.embedders.ollama import OllamaEmbedder
+from ingestion_service.core.embedders.factory import get_embedder
 from ingestion_service.core.vectorstore.base import VectorMetadata, VectorRecord
 from ingestion_service.core.vectorstore.pgvector_store import PgVectorStore
+from ingestion_service.core.chunks import Chunk
+from ingestion_service.core.config import reset_settings_cache
+import logging
 
+logging.basicConfig(level=logging.DEBUG)
 pytest_plugins = ["tests.conftest_db"]
 
 
-@pytest.mark.docker
 @pytest.mark.integration
+@pytest.mark.docker
 def test_pgvector_similarity_search(clean_vectors_table, test_database_url):
-    """
-    Test that PgVectorStore similarity_search returns correct top-k vectors
-    ordered by distance (<-> operator).
-    """
-    store = PgVectorStore(dsn=test_database_url, dimension=3)
+    reset_settings_cache()
+
+    # Use real Ollama embedder (768D)
+    embedder = cast(OllamaEmbedder, get_embedder("ollama"))
+    assert embedder.dimension == 768
+
+    store = PgVectorStore(
+        dsn=test_database_url,
+        dimension=embedder.dimension,  # 768, not 3!
+        provider="ollama",
+    )
+
+    # Create test texts that should have distinct embeddings
+    # Create test texts with CLEAR semantic distance from query
+    texts = [
+        "Chunk 1: machine learning algorithms",  # MOST similar to query
+        "Chunk 2: machine learning models",  # 2nd most similar
+        "Chunk 3: database indexing techniques",  # LEAST similar
+    ]
+
+    # Generate real embeddings
+    chunks = [
+        Chunk(chunk_id=f"c{i}", content=text, metadata={})
+        for i, text in enumerate(texts)
+    ]
+    embeddings = embedder.embed(chunks)
 
     records = [
         VectorRecord(
-            vector=[1.0, 0.0, 0.0],
+            vector=embeddings[0],
             metadata=VectorMetadata(
                 ingestion_id="ing-1",
                 chunk_id="c1",
                 chunk_index=0,
                 chunk_strategy="fixed",
-                chunk_text="Chunk 1 text",
+                chunk_text=texts[0],
                 source_metadata={},
             ),
         ),
         VectorRecord(
-            vector=[0.0, 1.0, 0.0],
+            vector=embeddings[1],
             metadata=VectorMetadata(
                 ingestion_id="ing-2",
                 chunk_id="c2",
                 chunk_index=1,
                 chunk_strategy="fixed",
-                chunk_text="Chunk 2 text",
+                chunk_text=texts[1],
                 source_metadata={},
             ),
         ),
         VectorRecord(
-            vector=[0.0, 0.0, 1.0],
+            vector=embeddings[2],
             metadata=VectorMetadata(
                 ingestion_id="ing-3",
                 chunk_id="c3",
                 chunk_index=2,
                 chunk_strategy="fixed",
-                chunk_text="Chunk 3 text",
+                chunk_text=texts[2],
                 source_metadata={},
             ),
         ),
@@ -54,13 +81,15 @@ def test_pgvector_similarity_search(clean_vectors_table, test_database_url):
 
     store.add(records)
 
-    query = [0.9, 0.1, 0.0]
-    results = store.similarity_search(query_vector=query, k=2)
+    # Query closest to first chunk
+    query_chunk = Chunk(chunk_id="query", content=texts[0], metadata={})
+    query_embedding = embedder.embed([query_chunk])[0]
+    results = store.similarity_search(query_vector=query_embedding, k=2)
 
     assert len(results) == 2
-    assert results[0].metadata.ingestion_id == "ing-1"
-    assert results[1].metadata.ingestion_id == "ing-2"
+    assert results[0].metadata.ingestion_id == "ing-1"  # Closest to itself
+    assert results[1].metadata.ingestion_id == "ing-2"  # Next closest
 
     store.delete_by_ingestion_id("ing-1")
-    remaining = store.similarity_search(query_vector=query, k=3)
+    remaining = store.similarity_search(query_vector=query_embedding, k=3)
     assert all(r.metadata.ingestion_id != "ing-1" for r in remaining)

--- a/tests/vectorstore/test_pgvector_store.py
+++ b/tests/vectorstore/test_pgvector_store.py
@@ -1,39 +1,61 @@
-# tests/vectorstore/test_pgvector_store.py
 import uuid
 import pytest
+from typing import cast
+from ingestion_service.core.embedders.ollama import OllamaEmbedder
+from ingestion_service.core.embedders.factory import get_embedder
 from ingestion_service.core.vectorstore.base import VectorMetadata, VectorRecord
 from ingestion_service.core.vectorstore.pgvector_store import PgVectorStore
+from ingestion_service.core.chunks import Chunk
+from ingestion_service.core.config import reset_settings_cache
 
-pytest_plugins = ["tests.conftest_db"]
 
-
-@pytest.mark.docker
 @pytest.mark.integration
+@pytest.mark.docker
 def test_pgvector_store_add_search_delete(clean_vectors_table, test_database_url):
-    store = PgVectorStore(dsn=test_database_url, dimension=3)
+    reset_settings_cache()
+    embedder = cast(OllamaEmbedder, get_embedder("ollama"))
+    assert embedder.dimension == 768
+
+    store = PgVectorStore(
+        dsn=test_database_url,
+        dimension=embedder.dimension,
+        provider="ollama",
+    )
 
     ingestion_id = str(uuid.uuid4())
     chunk_id = str(uuid.uuid4())
+    text = "PgVectorStore integration test with Ollama embeddings"
+
+    # FIXED: Create Chunk objects for embedder
+    test_chunk = Chunk(chunk_id=chunk_id, content=text, metadata={"test": True})
+    embedding = embedder.embed([test_chunk])[0]
 
     record = VectorRecord(
-        vector=[0.1, 0.2, 0.3],
+        vector=embedding,
         metadata=VectorMetadata(
             ingestion_id=ingestion_id,
             chunk_id=chunk_id,
             chunk_index=0,
             chunk_strategy="test",
-            chunk_text="Test chunk text",
-            source_metadata={},
+            chunk_text=text,
+            source_metadata={"test": True},
+            provider="ollama",
         ),
     )
 
     store.add([record])
 
-    results = store.similarity_search(query_vector=[0.1, 0.2, 0.31], k=1)
+    query_chunk = Chunk(chunk_id="query-id", content=text, metadata={"test": True})
+    query_embedding = embedder.embed([query_chunk])[0]
+    results = store.similarity_search(query_vector=query_embedding, k=1)
+
     assert len(results) == 1
-    assert results[0].metadata.ingestion_id == ingestion_id
-    assert results[0].metadata.chunk_id == chunk_id
+    r = results[0]
+    assert r.metadata.ingestion_id == ingestion_id
+    assert r.metadata.chunk_id == chunk_id
+    assert r.metadata.provider == "ollama"
+    assert r.metadata.chunk_text == text
 
     store.delete_by_ingestion_id(ingestion_id)
-    results_after_delete = store.similarity_search(query_vector=[0.1, 0.2, 0.3], k=1)
+    results_after_delete = store.similarity_search(query_vector=query_embedding, k=1)
     assert results_after_delete == []


### PR DESCRIPTION
✅ Users switch providers via config	PASS	test_factory_config_fallback() ✓ ✅ Provider metadata stored	PASS	PgVectorStore.persist() → vectors.provider ✓ ✅ Config validated at startup	PASS	Pydantic Settings() + factory ValueError ✓ ✅ Unit test: config parsing	PASS	test_embedder_factory.py → 3/3 green ✓ ✅ Integration test: provider switch	PASS	Docker tests + EMBEDDING_PROVIDER=ollama ✓