### PR TITLE
IS5-MS3 completed.

### DIFF
--- a/src/ingestion_service/core/vectorstore/async_ingest.py
+++ b/src/ingestion_service/core/vectorstore/async_ingest.py
@@ -2,21 +2,25 @@ from __future__ import annotations
 
 import asyncio
 from typing import Optional
-
 from ingestion_service.core.pipeline import IngestionPipeline
+from ingestion_service.core.vectorstore.base import VectorRecord, VectorMetadata
 
 
 class AsyncIngestionRunner:
     """
     Async wrapper around the synchronous IngestionPipeline.
-
-    MS2a MVP goal:
-    - non-blocking FastAPI ingestion
-    - reuse existing pipeline unchanged
     """
 
-    def __init__(self, pipeline: IngestionPipeline):
+    def __init__(
+        self,
+        pipeline: IngestionPipeline,
+        *,
+        provider: str = "mock",
+        source_type: str,
+    ):
         self._pipeline = pipeline
+        self._provider = provider
+        self._source_type = source_type
 
     async def ingest(
         self,
@@ -26,12 +30,24 @@ class AsyncIngestionRunner:
         source_metadata: Optional[dict] = None,
     ) -> None:
         loop = asyncio.get_running_loop()
+        chunks = self._pipeline._chunk(text, self._source_type, self._provider)
 
-        await loop.run_in_executor(
-            None,
-            self._pipeline._vector_store.persist,
-            self._pipeline._chunk(text),
-            self._pipeline._embed(self._pipeline._chunk(text)),
-            ingestion_id,
-            source_metadata,
-        )
+        embeddings = self._pipeline._embed(chunks)
+
+        records = [
+            VectorRecord(
+                vector=embedding,
+                metadata=VectorMetadata(
+                    ingestion_id=ingestion_id,
+                    chunk_id=chunk.chunk_id,
+                    chunk_index=i,
+                    chunk_strategy=chunk.metadata.get("chunk_strategy", "unknown"),
+                    chunk_text=chunk.content,
+                    source_metadata=source_metadata or {},
+                    provider=self._provider,
+                ),
+            )
+            for i, (chunk, embedding) in enumerate(zip(chunks, embeddings))
+        ]
+
+        await loop.run_in_executor(None, self._pipeline._vector_store.add, records)

--- a/src/ingestion_service/core/vectorstore/pgvector_store.py
+++ b/src/ingestion_service/core/vectorstore/pgvector_store.py
@@ -41,6 +41,12 @@ class PgVectorStore(VectorStore):
         )
         records = []
         for i, (chunk, embedding) in enumerate(zip(chunks, embeddings)):
+            # Merge enriched metadata with chunk content and indexing
+            metadata_dict = dict(chunk.metadata or {})
+            metadata_dict["chunk_text"] = (
+                chunk.content
+            )  # ensure text is stored in metadata
+
             record = VectorRecord(
                 vector=embedding,
                 metadata=VectorMetadata(
@@ -49,8 +55,8 @@ class PgVectorStore(VectorStore):
                     chunk_index=i,
                     chunk_strategy=chunk.metadata.get("chunk_strategy", "unknown"),
                     chunk_text=chunk.content,
-                    source_metadata=chunk.metadata,
-                    provider=self._provider,
+                    source_metadata=metadata_dict,
+                    provider=chunk.metadata.get("provider", self._provider),
                 ),
             )
             records.append(record)

--- a/src/ingestion_service/sample_test.py
+++ b/src/ingestion_service/sample_test.py
@@ -1,11 +1,9 @@
 # sample_test.py
 from ingestion_service.core.headless_ingest import HeadlessIngestor
 from ingestion_service.core.pipeline import IngestionPipeline
-from ingestion_service.core.validation import MockValidator  # real validator
-from ingestion_service.core.embedders.mock import MockEmbedder  # you already used this
-from ingestion_service.core.vectorstore.memory import (
-    MemoryVectorStore,
-)  # in-memory vector store
+from ingestion_service.core.validation import MockValidator
+from ingestion_service.core.embedders.mock import MockEmbedder
+from ingestion_service.core.vectorstore.memory import MemoryVectorStore
 
 
 def main():
@@ -16,19 +14,26 @@ def main():
         vector_store=MemoryVectorStore(),
     )
 
-    # Create headless ingestor
-    ingestor = HeadlessIngestor(pipeline=pipeline)
+    # Create headless ingestor WITH ingestion context
+    ingestor = HeadlessIngestor(
+        pipeline=pipeline,
+        source_type="text",
+        provider="mock",
+    )
 
-    # 1-2 five-word sentences
+    # 1–2 five-word sentences
     texts = ["Apples grow on tall trees.", "Dogs bark loudly at night."]
 
     # Ingest texts
     for idx, text in enumerate(texts, start=1):
         print(f"\n[TEST {idx}] Ingesting: {text}")
-        ingestor.ingest_text(text=text, ingestion_id=f"test_{idx}")
+        ingestor.ingest_text(
+            text=text,
+            ingestion_id=f"test_{idx}",
+        )
 
     # Final results
-    total = len(pipeline._vector_store._vectors)  # MemoryVectorStore stores in _vectors
+    total = len(pipeline._vector_store._vectors)
     print(f"\n[RESULT] Total records in vector store: {total}")
 
 

--- a/tests/core/pipeline/test_pipeline_persists_vectors.py
+++ b/tests/core/pipeline/test_pipeline_persists_vectors.py
@@ -41,7 +41,9 @@ def test_pipeline_persists_vectors_pgvector(clean_vectors_table, test_database_u
     text = "This is a test document for Docker integration pipeline."
 
     # --- Test end-to-end pipeline ---
-    pipeline.run(text=text, ingestion_id=ingestion_id)
+    pipeline.run(
+        text=text, ingestion_id=ingestion_id, source_type="text", provider="ollama"
+    )
 
     # --- Verify vectors persisted correctly ---
     query_chunk = Chunk(chunk_id="query", content=text, metadata={})

--- a/tests/core/test_headless_ingest.py
+++ b/tests/core/test_headless_ingest.py
@@ -37,7 +37,7 @@ def test_headless_ingestion_adds_vectors(clean_vectors_table, test_database_url)
         vector_store=vector_store,
     )
 
-    ingestor = HeadlessIngestor(pipeline)
+    ingestor = HeadlessIngestor(pipeline, provider="ollama", source_type="text")
 
     text = "Headless ingestion Docker integration test with multiple sentences."
     ingestion_id = str(uuid.uuid4())
@@ -53,3 +53,4 @@ def test_headless_ingestion_adds_vectors(clean_vectors_table, test_database_url)
     # Verify ingestion_id present and chunk_strategy properly set
     assert any(r.metadata.ingestion_id == ingestion_id for r in results)
     assert any(r.metadata.chunk_strategy == "simple" for r in results)
+    assert all(r.metadata.provider == "ollama" for r in results)

--- a/tests/core/test_pipeline.py
+++ b/tests/core/test_pipeline.py
@@ -57,7 +57,9 @@ def test_pipeline_dynamic_chunker(monkeypatch):
     )
 
     # Use the public `run()` method, ingestion_id is now actually used
-    pipeline.run(text=text, ingestion_id=ingestion_id)
+    pipeline.run(
+        text=text, ingestion_id=ingestion_id, source_type="text", provider="mock"
+    )
 
     # Check that chunks were persisted
     persisted_chunks, persisted_embeddings, persisted_id = vector_store.persisted[0]
@@ -87,7 +89,9 @@ def test_pipeline_explicit_chunker():
         vector_store=vector_store,
     )
 
-    pipeline.run(text=text, ingestion_id=ingestion_id)
+    pipeline.run(
+        text=text, ingestion_id=ingestion_id, source_type="text", provider="mock"
+    )
 
     persisted_chunks, _, persisted_id = vector_store.persisted[0]
     assert persisted_id == ingestion_id

--- a/tests/core/test_pipeline_with_embedder.py
+++ b/tests/core/test_pipeline_with_embedder.py
@@ -34,4 +34,6 @@ def test_pipeline_with_mock_embedder():
         vector_store=DummyVectorStore(),
     )
 
-    pipeline.run(text="hello", ingestion_id="test123")
+    pipeline.run(
+        text="hello", ingestion_id="test123", source_type="text", provider="mock"
+    )

--- a/tests/integration/test_ingest_text_file.py
+++ b/tests/integration/test_ingest_text_file.py
@@ -62,7 +62,8 @@ def test_text_file_ingest_creates_vectorsv2(clean_vectors_table, test_database_u
     metadata = {"filename": "test.txt"}
 
     response = client.post(
-        "/v1/ingest/file", files=files,
+        "/v1/ingest/file",
+        files=files,
         data={"metadata": json.dumps(metadata)},  # use the variable
     )
     assert response.status_code == 202


### PR DESCRIPTION
Metadata enrichment is now fully implemented and verified across the ingestion pipeline.

What’s done:

Each ingested item now consistently stores:

UTC timestamp (via ingestion_requests.created_at)

Source type (text, file, image)

Provider used (embedder / OCR provider)

Metadata is propagated end-to-end: API → pipeline → vector store

Provider information is persisted with vectors and validated on retrieval

Integration and unit tests added/updated to assert correct metadata persistence

All Docker and non-Docker tests pass cleanly

Linting, formatting, type checks, and pre-commit hooks are green